### PR TITLE
Add small fixes

### DIFF
--- a/lib/libcc2/GameLogic.cpp
+++ b/lib/libcc2/GameLogic.cpp
@@ -371,7 +371,7 @@ cc2::MoveState cc2::CheckMove(const MapData& map, const Tile* tile, int x, int y
 
         const Tile* peekBase = &peek->bottom();
         if (peekBase->type() == Tile::SteelWall || peekBase->type() == Tile::StyledWall
-                || peekBase->type() >= Tile::NUM_TILE_TYPES
+                || peekBase->type() >= Tile::NUM_NORMAL_TILE_TYPES
                 || peek->haveTile({Tile::MirrorPlayer, Tile::MirrorPlayer2, Tile::BlueTank,
                                    Tile::YellowTank, Tile::DirtBlock, Tile::IceBlock,
                                    Tile::DirBlock})) {

--- a/lib/libcc2/Map.cpp
+++ b/lib/libcc2/Map.cpp
@@ -96,6 +96,8 @@ void cc2::MapOption::write(ccl::Stream* stream) const
         throw ccl::IOError(ccl::RuntimeError::tr("Error writing to stream"));
 }
 
+// Create the constexpr from Map.h
+constexpr std::array<cc2::Tile::Type, 4> cc2::Tile::NotablePosthookTypes;
 
 cc2::Tile::Tile(const Tile& copy)
     : m_type(copy.m_type), m_direction(copy.m_direction),

--- a/lib/libcc2/Map.cpp
+++ b/lib/libcc2/Map.cpp
@@ -340,6 +340,10 @@ bool cc2::Tile::haveLower(int type)
     case Bribe:
     case SpeedShoes:
     case Hook:
+    case UNUSED_94:
+    case UNUSED_9f:
+    case UNUSED_a3:
+    case UNUSED_f3:
         return true;
     default:
         return false;
@@ -374,6 +378,7 @@ bool cc2::Tile::haveDirection(int type)
     case DirBlock:
     case FloorMimic:
     case Ghost:
+    case UNUSED_a3:
         return true;
     default:
         return false;
@@ -434,6 +439,9 @@ cc2::Tile::TileClass cc2::Tile::tileClass(int type)
     case Bribe:
     case SpeedShoes:
     case Hook:
+    case UNUSED_94:
+    case UNUSED_9f:
+    case UNUSED_f3:
         return ClassItem;
     case Walker:
     case Ship:
@@ -451,6 +459,7 @@ cc2::Tile::TileClass cc2::Tile::tileClass(int type)
     case Rover:
     case FloorMimic:
     case Ghost:
+    case UNUSED_a3:
         return ClassCreature;
     case Player:
     case Player2:
@@ -1119,9 +1128,8 @@ void cc2::MapData::read(ccl::Stream* stream, size_t size)
     m_map = new Tile[mapSize];
     for (size_t i = 0; i < mapSize; ++i)
         m_map[i].read(stream);
-
-    if (start + (long)size != stream->tell())
-        throw ccl::FormatError(ccl::RuntimeError::tr("Failed to parse map data"));
+    if (start + (long)size < stream->tell())
+       throw ccl::FormatError(ccl::RuntimeError::tr("Failed to parse map data (%1 extra bytes in map data)").arg(start + (long)size - stream->tell()));
 }
 
 void cc2::MapData::write(ccl::Stream* stream) const

--- a/lib/libcc2/Map.cpp
+++ b/lib/libcc2/Map.cpp
@@ -29,13 +29,15 @@ void cc2::MapOption::setReplayMD5(const uint8_t* md5)
 }
 
 #define KNOWN_OPTION_LENGTH 25
+#define BLOB_PATTERN 24
 
 void cc2::MapOption::read(ccl::Stream* stream, size_t size)
 {
-    // We treat all fields as optional with a zero-default
+    // We treat all fields as optional with a zero-default (except for blob pattern, which has 1 as default)
     size_t alloc_size = std::max((size_t)KNOWN_OPTION_LENGTH, size);
     std::unique_ptr<uint8_t[]> buffer(new uint8_t[alloc_size]);
     memset(buffer.get(), 0, alloc_size);
+    buffer[BLOB_PATTERN] = 1;
     if (stream->read(buffer.get(), 1, size) != size)
         throw ccl::IOError(ccl::RuntimeError::tr("Read past end of stream"));
 
@@ -85,7 +87,7 @@ void cc2::MapOption::write(ccl::Stream* stream) const
     Q_ASSERT((bufp - buffer) == KNOWN_OPTION_LENGTH);
 
     size_t writeLen = KNOWN_OPTION_LENGTH;
-    while (writeLen > 3 && buffer[writeLen - 1] == 0)
+    while (writeLen > 3 && buffer[writeLen - 1] == (writeLen - 1 == BLOB_PATTERN ? 1 : 0))
         --writeLen;
 
     // Never cut in the middle of the replay checksum

--- a/lib/libcc2/Map.h
+++ b/lib/libcc2/Map.h
@@ -200,9 +200,13 @@ public:
         Flag2x, DirBlock, FloorMimic, GreenBomb, GreenChip,
         UNUSED_85, UNUSED_86, RevLogicButton, Switch_Off, Switch_On,
         KeyThief, Ghost, SteelFoil, Turtle, Eye, Bribe, SpeedShoes,
-        UNUSED_91, Hook, UNUSED_94 = 0x94, UNUSED_9f = 0x9f,
-        UNUSED_a3 = 0xa3, UNUSED_f3 = 0xf3,
-        NUM_TILE_TYPES,
+        UNUSED_91, Hook, NUM_NORMAL_TILE_TYPES, UNUSED_94 = 0x94,
+        UNUSED_9f = 0x9f, UNUSED_a3 = 0xa3, UNUSED_f3 = 0xf3,
+    };
+
+    static constexpr std::array<Type, 4> NotablePosthookTypes = {
+        UNUSED_94, UNUSED_9f,
+        UNUSED_a3, UNUSED_f3,
     };
 
     enum Direction { InvalidDir = -1, North, East, South, West };

--- a/lib/libcc2/Map.h
+++ b/lib/libcc2/Map.h
@@ -200,7 +200,8 @@ public:
         Flag2x, DirBlock, FloorMimic, GreenBomb, GreenChip,
         UNUSED_85, UNUSED_86, RevLogicButton, Switch_Off, Switch_On,
         KeyThief, Ghost, SteelFoil, Turtle, Eye, Bribe, SpeedShoes,
-        UNUSED_91, Hook,
+        UNUSED_91, Hook, UNUSED_94 = 0x94, UNUSED_9f = 0x9f,
+        UNUSED_a3 = 0xa3, UNUSED_f3 = 0xf3,
         NUM_TILE_TYPES,
     };
 

--- a/lib/libcc2/Tileset.cpp
+++ b/lib/libcc2/Tileset.cpp
@@ -723,6 +723,7 @@ void CC2ETileset::drawLayer(QPainter& painter, int x, int y, const cc2::Tile* ti
         // based on the "direction" value...
         //painter.drawPixmap(x, y, m_gfx[cc2::G_Player_N]);
         painter.drawPixmap(x, y, m_gfx[cc2::G_InvalidBase]);
+        drawArrow(painter, x, y, tile->direction());
         break;
     case cc2::Tile::LogicButton:
         drawWires(painter, x, y, tile->modifier(), cc2::G_Floor);
@@ -997,7 +998,8 @@ void CC2ETileset::drawLayer(QPainter& painter, int x, int y, const cc2::Tile* ti
         painter.drawPixmap(x, y, m_gfx[cc2::G_Hook]);
         break;
     default:
-        painter.drawPixmap(x, y, m_gfx[cc2::G_Floor]);
+        if (tile->layer() == cc2::Tile::BaseLayer)
+            painter.drawPixmap(x, y, m_gfx[cc2::G_Floor]);
         painter.drawPixmap(x, y, m_gfx[cc2::G_InvalidBase]);
         if (tile->haveDirection())
             drawArrow(painter, x, y, tile->direction());

--- a/src/CC2Edit/CC2Edit.cpp
+++ b/src/CC2Edit/CC2Edit.cpp
@@ -608,6 +608,10 @@ CC2EditMain::CC2EditMain(QWidget* parent)
         cc2::Tile(cc2::Tile::UNUSED_85),
         cc2::Tile(cc2::Tile::UNUSED_86),
         cc2::Tile(cc2::Tile::UNUSED_91),
+        cc2::Tile(cc2::Tile::UNUSED_94),
+        cc2::Tile(cc2::Tile::UNUSED_9f),
+        cc2::Tile(cc2::Tile::UNUSED_a3),
+        cc2::Tile(cc2::Tile::UNUSED_f3)
     });
     tileBox->addItem(tileLists[ListAdvanced], tr("Advanced"));
 

--- a/src/CC2Edit/CC2Edit.cpp
+++ b/src/CC2Edit/CC2Edit.cpp
@@ -28,6 +28,7 @@
 #include "libcc2/GameLogic.h"
 #include "CommonWidgets/CCTools.h"
 #include "CommonWidgets/EditorTabWidget.h"
+#include "Preferences.h"
 
 #include <QApplication>
 #include <QDesktopServices>
@@ -115,6 +116,8 @@ CC2EditMain::CC2EditMain(QWidget* parent)
     m_actions[ActionGenReport] = new QAction(tr("Generate &Report"), this);
     m_actions[ActionGenReport]->setStatusTip(tr("Generate an HTML report of the current game"));
     m_actions[ActionGenReport]->setEnabled(false);
+    m_actions[ActionPreferences] = new QAction(tr("&Prefrerences..."), this);
+    m_actions[ActionPreferences]->setStatusTip(tr("Change CC2Edit preferences"));
     m_actions[ActionExit] = new QAction(ICON("application-exit"), tr("E&xit"), this);
     m_actions[ActionExit]->setStatusTip(tr("Close CC2Edit"));
 
@@ -757,6 +760,7 @@ CC2EditMain::CC2EditMain(QWidget* parent)
     fileMenu->addSeparator();
     fileMenu->addAction(m_actions[ActionGenReport]);
     fileMenu->addSeparator();
+    fileMenu->addAction(m_actions[ActionPreferences]);
     fileMenu->addAction(m_actions[ActionExit]);
 
     QMenu* editMenu = menuBar()->addMenu(tr("&Edit"));
@@ -866,6 +870,10 @@ CC2EditMain::CC2EditMain(QWidget* parent)
     });
     connect(m_actions[ActionCloseGame], &QAction::triggered, this, &CC2EditMain::closeScript);
     connect(m_actions[ActionGenReport], &QAction::triggered, this, &CC2EditMain::onReportAction);
+    connect(m_actions[ActionPreferences], &QAction::triggered, this, [] {
+        PreferencesDialog dlg;
+        dlg.exec();
+    });
     connect(m_actions[ActionExit], &QAction::triggered, this, &CC2EditMain::close);
 
     connect(m_actions[ActionSelect], &QAction::toggled, this, &CC2EditMain::onSelectToggled);
@@ -1053,8 +1061,15 @@ CC2EditMain::CC2EditMain(QWidget* parent)
 
 void CC2EditMain::createNewMap()
 {
+    QSettings settings;
     auto map = new cc2::Map;
-    map->mapData().resize(32, 32);
+    map->mapData().resize(
+                settings.value(QStringLiteral("DefaultMapWidth"), 32).toUInt(),
+                settings.value(QStringLiteral("DefaultMapHeight"), 32).toUInt()
+    );
+    if (settings.value(QStringLiteral("UseDefaultAuthor"), false).toBool()) {
+        map->setAuthor(settings.value(QStringLiteral("AuthorName")).toString().toStdString());
+    }
     addEditor(map, QString(), false);
     map->unref();
 

--- a/src/CC2Edit/CC2Edit.h
+++ b/src/CC2Edit/CC2Edit.h
@@ -137,7 +137,7 @@ private slots:
 private:
     enum ActionType {
         ActionNewMap, ActionNewScript, ActionOpen, ActionImportCC1, ActionSave,
-        ActionSaveAs, ActionCloseTab, ActionCloseGame, ActionGenReport, ActionExit,
+        ActionSaveAs, ActionCloseTab, ActionCloseGame, ActionGenReport, ActionPreferences, ActionExit,
         ActionSelect, ActionCut, ActionCopy, ActionPaste, ActionClear,
         ActionUndo, ActionRedo, ActionDrawPencil, ActionDrawLine, ActionDrawRect,
         ActionDrawFill, ActionDrawFlood, ActionPathMaker, ActionDrawWire,

--- a/src/CC2Edit/CMakeLists.txt
+++ b/src/CC2Edit/CMakeLists.txt
@@ -29,6 +29,7 @@ set(CC2Edit_HEADERS
     TestSetup.h
     TileInspector.h
     TileWidgets.h
+    Preferences.h
 )
 
 set(CC2Edit_SOURCES
@@ -44,6 +45,7 @@ set(CC2Edit_SOURCES
     TestSetup.cpp
     TileInspector.cpp
     TileWidgets.cpp
+    Preferences.cpp
 )
 
 if(WIN32)

--- a/src/CC2Edit/Preferences.cpp
+++ b/src/CC2Edit/Preferences.cpp
@@ -1,0 +1,105 @@
+/******************************************************************************
+ * This file is part of CCTools.                                              *
+ *                                                                            *
+ * CCTools is free software: you can redistribute it and/or modify            *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * CCTools is distributed in the hope that it will be useful,                 *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with CCTools.  If not, see <http://www.gnu.org/licenses/>.           *
+ ******************************************************************************/
+
+#include "Preferences.h"
+#include "ResizeDialog.h"
+
+#include <QSettings>
+#include <QLabel>
+#include <QLineEdit>
+#include <QDialogButtonBox>
+#include <QToolButton>
+#include <QGridLayout>
+#include <QIntValidator>
+#include <QPushButton>
+
+PreferencesDialog::PreferencesDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Preferences"));
+
+    QSettings settings;
+
+    m_useDefaultAuthor = new QCheckBox(tr("Use default &author name: "));
+    m_useDefaultAuthor->setChecked(settings.value(QStringLiteral("UseDefaultAuthor"), false).toBool());
+
+    m_authorName = new QLineEdit(settings.value(QStringLiteral("AuthorName")).toString(), this);
+    m_authorName->setEnabled(m_useDefaultAuthor->isChecked());
+
+    m_defaultSize = new QLineEdit(this);
+    m_defaultSize->setEnabled(false);
+    m_defaultSize->setText(QStringLiteral("%1x%2")
+                       .arg(settings.value(QStringLiteral("DefaultMapWidth"), 32).toUInt())
+                       .arg(settings.value(QStringLiteral("DefaultMapHeight"), 32).toUInt()));
+    auto defaultSizeLabel = new QLabel(tr("Default Map &Size:"), this);
+    defaultSizeLabel->setBuddy(m_defaultSize);
+    auto resizeButton = new QPushButton(tr("&Resize..."), this);
+    resizeButton->setStatusTip(tr("Resize the default level size"));
+
+    auto buttons = new QDialogButtonBox(
+            QDialogButtonBox::Save | QDialogButtonBox::Cancel,
+            Qt::Horizontal, this);
+
+    auto layout = new QGridLayout(this);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setVerticalSpacing(4);
+    layout->setHorizontalSpacing(4);
+    int row = 0;
+
+    layout->addWidget(m_useDefaultAuthor, row, 0);
+    layout->addWidget(m_authorName, row, 1);
+    layout->addWidget(defaultSizeLabel, ++row, 0);
+    layout->addWidget(m_defaultSize, row, 1);
+    layout->addWidget(resizeButton, row, 2);
+    layout->addItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding),
+                    ++row, 0, 1, 3);
+    layout->addWidget(buttons, ++row, 0, 1, 3);
+    resize(400, sizeHint().height());
+
+    connect(m_useDefaultAuthor, &QCheckBox::toggled, this, &PreferencesDialog::onUseDefaultAuthorChanged);
+    connect(resizeButton, &QPushButton::pressed, this, &PreferencesDialog::onDefaultSizeResize);
+
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(buttons, &QDialogButtonBox::accepted, this, &PreferencesDialog::onSaveSettings);
+}
+
+void PreferencesDialog::onSaveSettings()
+{
+    QSettings settings;
+    settings.setValue(QStringLiteral("UseDefaultAuthor"), m_useDefaultAuthor->isChecked());
+    settings.setValue(QStringLiteral("AuthorName"), m_authorName->text());
+    accept();
+}
+
+void PreferencesDialog::onUseDefaultAuthorChanged() {
+    m_authorName->setEnabled(m_useDefaultAuthor->isChecked());
+}
+
+void PreferencesDialog::onDefaultSizeResize() {
+    QSettings settings;
+    ResizeDialog dialog(QSize(
+                            settings.value(QStringLiteral("DefaultMapWidth"), 32).toUInt(),
+                            settings.value(QStringLiteral("DefaultMapHeight"), 32).toUInt()
+                       ), this);
+    if (dialog.exec() == QDialog::Accepted) {
+        settings.setValue(QStringLiteral("DefaultMapWidth"), dialog.requestedSize().width());
+        settings.setValue(QStringLiteral("DefaultMapHeight"), dialog.requestedSize().height());
+        m_defaultSize->setText(QStringLiteral("%1x%2")
+                           .arg(dialog.requestedSize().width())
+                           .arg(dialog.requestedSize().height()));
+    }
+}

--- a/src/CC2Edit/Preferences.h
+++ b/src/CC2Edit/Preferences.h
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * This file is part of CCTools.                                              *
+ *                                                                            *
+ * CCTools is free software: you can redistribute it and/or modify            *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * CCTools is distributed in the hope that it will be useful,                 *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with CCTools.  If not, see <http://www.gnu.org/licenses/>.           *
+ ******************************************************************************/
+
+#ifndef _CC2_PREFERENCES_H
+#define _CC2_PREFERENCES_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QCheckBox>
+
+class PreferencesDialog : public QDialog {
+public:
+    PreferencesDialog(QWidget* parent = nullptr);
+private:
+    QCheckBox* m_useDefaultAuthor;
+    QLineEdit* m_authorName;
+    QLineEdit* m_defaultSize;
+private slots:
+    void onSaveSettings();
+    void onUseDefaultAuthorChanged();
+    void onDefaultSizeResize();
+};
+
+#endif

--- a/src/CC2Edit/TestSetup.cpp
+++ b/src/CC2Edit/TestSetup.cpp
@@ -25,6 +25,7 @@
 #include <QGridLayout>
 #include <QIntValidator>
 #include <QFileDialog>
+#include <QCheckBox>
 #include "CommonWidgets/CCTools.h"
 #include "CommonWidgets/PathCompleter.h"
 
@@ -80,6 +81,10 @@ TestSetupDialog::TestSetupDialog(QWidget* parent)
                                              DEFAULT_LEXY_URL).toString(), this);
     auto lblLexyUrl = new QLabel(tr("&Lexy's Labyrinth URL:"), this);
     lblLexyUrl->setBuddy(m_lexyUrl);
+
+    m_autoKill = new QCheckBox(tr("Automatically kill the current test process when spawning a new one"), this);
+    m_autoKill->setChecked(settings.value(QStringLiteral("AutoKillTest"), true).toBool());
+
     auto buttons = new QDialogButtonBox(
             QDialogButtonBox::Save | QDialogButtonBox::Cancel,
             Qt::Horizontal, this);
@@ -115,6 +120,7 @@ TestSetupDialog::TestSetupDialog(QWidget* parent)
             "</ul>"), this);
     chips1Label->setWordWrap(true);
     layout->addWidget(chips1Label, ++row, 0, 1, 3);
+    layout->addWidget(m_autoKill, ++row, 0, 1, 3);
     layout->addItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding),
                     ++row, 0, 1, 3);
     layout->addWidget(buttons, ++row, 0, 1, 3);
@@ -138,6 +144,7 @@ void TestSetupDialog::onSaveSettings()
 #endif
     settings.setValue(QStringLiteral("Chips2Exe"), m_chips2Path->text());
     settings.setValue(QStringLiteral("LexyUrl"), m_lexyUrl->text());
+    settings.setValue(QStringLiteral("AutoKillTest"), m_autoKill->isChecked());
     accept();
 }
 

--- a/src/CC2Edit/TestSetup.h
+++ b/src/CC2Edit/TestSetup.h
@@ -21,6 +21,7 @@
 #include <QDialog>
 
 class QLineEdit;
+class QCheckBox;
 
 class TestSetupDialog : public QDialog {
     Q_OBJECT
@@ -35,6 +36,7 @@ private:
 #endif
     QLineEdit* m_chips2Path;
     QLineEdit* m_lexyUrl;
+    QCheckBox* m_autoKill;
 
 private slots:
     void onSaveSettings();

--- a/src/CC2Edit/TileInspector.cpp
+++ b/src/CC2Edit/TileInspector.cpp
@@ -63,14 +63,17 @@ TileInspector::TileInspector(QWidget* parent)
     connect(m_moveLayerUp, &QAction::triggered, this, &TileInspector::moveLayerUp);
 
     m_tileType = new QComboBox(this);
-    for (int i = 0; i < cc2::Tile::NUM_TILE_TYPES; ++i) {
+    for (int i = 0; i < cc2::Tile::NUM_NORMAL_TILE_TYPES; ++i) {
         if (i == cc2::Tile::Modifier8 || i == cc2::Tile::Modifier16
                 || i == cc2::Tile::Modifier32)
             continue;
 
         m_tileType->addItem(CC2ETileset::baseName((cc2::Tile::Type)i), i);
     }
-    m_tileType->insertSeparator(cc2::Tile::NUM_TILE_TYPES);
+    for (cc2::Tile::Type i: cc2::Tile::NotablePosthookTypes) {
+        m_tileType->addItem(CC2ETileset::baseName((cc2::Tile::Type)i), i);
+    };
+    m_tileType->insertSeparator(cc2::Tile::NUM_NORMAL_TILE_TYPES + cc2::Tile::NotablePosthookTypes.size());
     m_tileType->addItem(tr("Other:"));
     auto tileTypeLabel = new QLabel(tr("Base &Type:"), this);
     tileTypeLabel->setBuddy(m_tileType);
@@ -195,7 +198,7 @@ void TileInspector::tryAccept()
                     tr("Invalid tile type (%1).  Tile type must not be a modifier tile.")
                     .arg(tp->type()));
             return;
-        } else if (tp->type() >= cc2::Tile::NUM_TILE_TYPES) {
+        } else if (tp->type() >= cc2::Tile::NUM_NORMAL_TILE_TYPES) {
             rangeTile = tp->type();
         }
     }

--- a/src/CCEdit/CCEdit.h
+++ b/src/CCEdit/CCEdit.h
@@ -130,6 +130,7 @@ private:
     void doLevelsetLoad();
     void setLevelsetFilename(const QString& filename);
     void populateRecentFiles();
+    void killSubProc();
 
 private slots:
     void onOpenAction();

--- a/src/CCEdit/CCEdit.h
+++ b/src/CCEdit/CCEdit.h
@@ -67,7 +67,7 @@ private:
     enum ActionType {
         ActionNew, ActionOpen, ActionSave, ActionSaveAs, ActionCloseTab,
         ActionCloseLevelset,
-        ActionGenReport, ActionExit, ActionSelect, ActionCut, ActionCopy,
+        ActionGenReport, ActionPreferences, ActionExit, ActionSelect, ActionCut, ActionCopy,
         ActionPaste, ActionClear, ActionUndo, ActionRedo, ActionDrawPencil,
         ActionDrawLine, ActionDrawRect, ActionDrawFill, ActionDrawFlood,
         ActionPathMaker, ActionConnect, ActionAdvancedMech, ActionInspectTiles,

--- a/src/CCEdit/CMakeLists.txt
+++ b/src/CCEdit/CMakeLists.txt
@@ -29,6 +29,7 @@ set(CCEdit_HEADERS
     Organizer.h
     TileInspector.h
     LevelProperties.h
+    Preferences.h
 )
 
 set(CCEdit_SOURCES
@@ -44,6 +45,7 @@ set(CCEdit_SOURCES
     Organizer.cpp
     TileInspector.cpp
     LevelProperties.cpp
+    Preferences.cpp
 )
 
 if(WIN32)

--- a/src/CCEdit/Preferences.cpp
+++ b/src/CCEdit/Preferences.cpp
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * This file is part of CCTools.                                              *
+ *                                                                            *
+ * CCTools is free software: you can redistribute it and/or modify            *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * CCTools is distributed in the hope that it will be useful,                 *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with CCTools.  If not, see <http://www.gnu.org/licenses/>.           *
+ ******************************************************************************/
+
+#include "Preferences.h"
+
+#include <QSettings>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QPushButton>
+
+PreferencesDialog::PreferencesDialog(QWidget* parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Preferences"));
+
+    QSettings settings;
+
+    m_useDefaultAuthor = new QCheckBox(tr("Use default &author name: "));
+    m_useDefaultAuthor->setChecked(settings.value(QStringLiteral("UseDefaultAuthor"), false).toBool());
+
+    m_authorName = new QLineEdit(settings.value(QStringLiteral("AuthorName")).toString(), this);
+    m_authorName->setEnabled(m_useDefaultAuthor->isChecked());
+
+    auto buttons = new QDialogButtonBox(
+            QDialogButtonBox::Save | QDialogButtonBox::Cancel,
+            Qt::Horizontal, this);
+
+    auto layout = new QGridLayout(this);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setVerticalSpacing(4);
+    layout->setHorizontalSpacing(4);
+    int row = 0;
+
+    layout->addWidget(m_useDefaultAuthor, row, 0);
+    layout->addWidget(m_authorName, row, 1);
+    layout->addItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding),
+                    ++row, 0, 1, 3);
+    layout->addWidget(buttons, ++row, 0, 1, 3);
+    resize(400, sizeHint().height());
+
+    connect(m_useDefaultAuthor, &QCheckBox::toggled, this, &PreferencesDialog::onUseDefaultAuthorChanged);
+
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(buttons, &QDialogButtonBox::accepted, this, &PreferencesDialog::onSaveSettings);
+}
+
+void PreferencesDialog::onSaveSettings()
+{
+    QSettings settings;
+    settings.setValue(QStringLiteral("UseDefaultAuthor"), m_useDefaultAuthor->isChecked());
+    settings.setValue(QStringLiteral("AuthorName"), m_authorName->text());
+    accept();
+}
+
+void PreferencesDialog::onUseDefaultAuthorChanged() {
+    m_authorName->setEnabled(m_useDefaultAuthor->isChecked());
+}

--- a/src/CCEdit/Preferences.h
+++ b/src/CCEdit/Preferences.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+ * This file is part of CCTools.                                              *
+ *                                                                            *
+ * CCTools is free software: you can redistribute it and/or modify            *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation, either version 3 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * CCTools is distributed in the hope that it will be useful,                 *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with CCTools.  If not, see <http://www.gnu.org/licenses/>.           *
+ ******************************************************************************/
+
+#ifndef _PREFERENCES_H
+#define _PREFERENCES_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QCheckBox>
+
+class PreferencesDialog : public QDialog {
+public:
+    PreferencesDialog(QWidget* parent = nullptr);
+private:
+    QCheckBox* m_useDefaultAuthor;
+    QLineEdit* m_authorName;
+private slots:
+    void onSaveSettings();
+    void onUseDefaultAuthorChanged();
+};
+
+#endif

--- a/src/CCEdit/TestSetup.cpp
+++ b/src/CCEdit/TestSetup.cpp
@@ -144,6 +144,7 @@ void TestSetupDialog::onSaveSettings()
     settings.setValue(QStringLiteral("TestCCPatch"), m_useCCPatch->isChecked());
     settings.setValue(QStringLiteral("TestPGPatch"), m_usePGPatch->isChecked());
     settings.setValue(QStringLiteral("LexyUrl"), m_lexyUrl->text());
+    settings.setValue(QStringLiteral("AutoKillTest"), m_autoKill->isChecked());
     accept();
 }
 

--- a/src/CCEdit/TestSetup.cpp
+++ b/src/CCEdit/TestSetup.cpp
@@ -89,6 +89,9 @@ TestSetupDialog::TestSetupDialog(QWidget* parent)
     auto lblLexyUrl = new QLabel(tr("&Lexy's Labyrinth URL:"), this);
     lblLexyUrl->setBuddy(m_lexyUrl);
 
+    m_autoKill = new QCheckBox(tr("Automatically kill the current test process when spawning a new one"), this);
+    m_autoKill->setChecked(settings.value(QStringLiteral("AutoKillTest"), true).toBool());
+
     auto layout = new QGridLayout(this);
     layout->setContentsMargins(8, 8, 8, 8);
     layout->setVerticalSpacing(4);
@@ -119,6 +122,7 @@ TestSetupDialog::TestSetupDialog(QWidget* parent)
     winevdmLabel->setOpenExternalLinks(true);
     layout->addWidget(winevdmLabel, ++row, 0, 1, 3);
 #endif
+    layout->addWidget(m_autoKill, ++row, 0, 1, 3);
     layout->addItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding),
                     ++row, 0, 1, 3);
     layout->addWidget(buttons, ++row, 0, 1, 3);

--- a/src/CCEdit/TestSetup.h
+++ b/src/CCEdit/TestSetup.h
@@ -36,6 +36,7 @@ private:
 
     QCheckBox* m_useCCPatch;
     QCheckBox* m_usePGPatch;
+    QCheckBox* m_autoKill;
 
 private slots:
     void onSaveSettings();


### PR DESCRIPTION
Adds multiple small fixes and features which I don't think are too controversial:
* Bug fix: There are some tiles after the hook tile (post-hook tiles) for which CC2 requires additional data for them (layer and/or direction), but CC2Edit doesn't handle that.
* Bug fix: CC2Edit assumes the default Blob Pattern setting is Deterministic (`0`), which is not the case, 4 Patterns (`1`) is.
* Feature: An option which automatically kills the old test processes when trying to spawn a new one.
* Feature: A preference menu where the default author name and map size (CC2Edit only) can be set.