### PR TITLE
Add file filter for *.DAT in CCEdit and CC2Edit

### DIFF
--- a/src/CC2Edit/CC2Edit.cpp
+++ b/src/CC2Edit/CC2Edit.cpp
@@ -1703,7 +1703,7 @@ void CC2EditMain::onImportCC1Action()
     QSettings settings;
     QString filename = QFileDialog::getOpenFileName(this, tr("Import Map..."),
                             settings.value(QStringLiteral("Import/DialogDir")).toString(),
-                            tr("CC1 Levelsets (*.ccl *.dat)"));
+                            tr("CC1 Levelsets (*.ccl *.dat *.DAT)"));
     if (!filename.isEmpty()) {
         ImportDialog dialog(this);
         dialog.loadLevelset(filename);

--- a/src/CCEdit/CCEdit.cpp
+++ b/src/CCEdit/CCEdit.cpp
@@ -1397,7 +1397,7 @@ void CCEditMain::onOpenAction()
     QSettings settings;
     QString filename = QFileDialog::getOpenFileName(this, tr("Open Levelset..."),
                             settings.value(QStringLiteral("DialogDir")).toString(),
-                            tr("All Levelsets (*.dat *.dac *.ccl)"));
+                            tr("All Levelsets (*.dat *.DAT *.dac *.ccl)"));
     if (!filename.isEmpty()) {
         loadLevelset(filename);
         settings.setValue(QStringLiteral("DialogDir"),
@@ -1417,7 +1417,7 @@ void CCEditMain::onSaveAsAction()
 {
     QSettings settings;
     QString filter = m_useDac ? tr("TWorld Levelsets (*.dac)")
-                              : tr("CC Levelsets (*.dat *.ccl)");
+                              : tr("CC Levelsets (*.dat *.DAT *.ccl)");
 
     if (m_levelsetFilename.isEmpty())
         m_levelsetFilename = settings.value(QStringLiteral("DialogDir")).toString();


### PR DESCRIPTION
In Linux and presumably other *nix OSs with case sensitive file handling, CCEdit and CC2Edit are unable to see the traditional CHIPS.DAT file in the file dialog, so I added *.DAT in addition to *.dat.