### PR TITLE
Don't reject DAT files with map detail set to 0

### DIFF
--- a/lib/libcc1/Levelset.cpp
+++ b/lib/libcc1/Levelset.cpp
@@ -249,9 +249,9 @@ long ccl::LevelData::read(ccl::Stream* stream, bool forClipboard)
     m_chips = stream->read16();
     dataSize -= 3 * sizeof(unsigned short);
 
-    long mapDetail = stream->read16();
+    uint16_t compressionType = stream->read16();
 
-    if (mapDetail != 1 && mapDetail != 0)
+    if (compressionType != 0 && compressionType != 1)
         throw ccl::IOError(ccl::RuntimeError::tr("Invalid map data field"));
     dataSize -= m_map.read(stream) + sizeof(unsigned short);
 

--- a/lib/libcc1/Levelset.cpp
+++ b/lib/libcc1/Levelset.cpp
@@ -249,7 +249,9 @@ long ccl::LevelData::read(ccl::Stream* stream, bool forClipboard)
     m_chips = stream->read16();
     dataSize -= 3 * sizeof(unsigned short);
 
-    if (stream->read16() != 1)
+    long mapDetail = stream->read16();
+
+    if (mapDetail != 1 && mapDetail != 0)
         throw ccl::IOError(ccl::RuntimeError::tr("Invalid map data field"));
     dataSize -= m_map.read(stream) + sizeof(unsigned short);
 


### PR DESCRIPTION
This is a very simple fix to allow DAT files with the map detail set to 0. Tile World accepts both 0 and 1, and [CCTools](https://github.com/ChipMcCallahan/CCTools) emits 0 map detail by default, meaning CCEdit doesn't open those files without this change.