### PR TITLE
Update C2G template

### DIFF
--- a/src/CC2Edit/CC2Edit.cpp
+++ b/src/CC2Edit/CC2Edit.cpp
@@ -1057,6 +1057,10 @@ void CC2EditMain::createNewScript()
     auto editor = addScriptEditor(QString());
     editor->setPlainText(QStringLiteral(
                 "game \"My CC2 Game\"\n"
+                "; meta by: Put your name here\n"
+                "; meta description: A short-medium description of the set\n"
+                "; Rate the difficulty of the set between 1 and 5 (decimals allowed)\n"
+                "; meta difficulty: 3\n"
                 "0 flags =\n"
                 "0 score =\n"
                 "0 speed =\n"

--- a/src/CC2Edit/syntax/cc2game.xml
+++ b/src/CC2Edit/syntax/cc2game.xml
@@ -80,6 +80,7 @@
 
       <context name="Comment" attribute="Comment" lineEndContext="#pop">
         <DetectSpaces />
+        <RegExpr attribute="Comment Metadata" String="meta.+" context="#stay" />
         <IncludeRules context="##Alerts" />
         <DetectIdentifier />
       </context>
@@ -102,6 +103,7 @@
       <itemData name="String" defStyleNum="dsString"/>
       <itemData name="String Char" defStyleNum="dsChar"/>
       <itemData name="Comment" defStyleNum="dsComment"/>
+      <itemData name="Comment Metadata" defStyleNum="dsPreprocessor"/>
     </itemDatas>
   </highlighting>
 


### PR DESCRIPTION
Fixes `speed`'s name by removing the unnecessary hi prefix, and also adds some basic set metadata, which is kinda like CCX for DAT's, but in C2G comments instead!